### PR TITLE
Use stable version of ConstraintLayout

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,7 +103,7 @@ dependencies {
     implementation("androidx.compose.runtime:runtime-livedata")
     implementation("androidx.compose.runtime:runtime-rxjava3")
     // ConstraintLayout
-    implementation("androidx.constraintlayout:constraintlayout-compose:1.1.0-alpha10")
+    implementation("androidx.constraintlayout:constraintlayout-compose:1.0.1")
     // Navigation
     implementation("androidx.navigation:navigation-compose:2.5.3")
 


### PR DESCRIPTION
The alpha version depends on 1.5.0-beta01 of compose dependencies. Downgrade so we actually use the stable 1.4.3 compose dependencies. This also fixes using the LayoutInspector.